### PR TITLE
FRW-1928 Fixed response code for OAuth token creation endpoint.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
     bootstrapFiles:
        - tests/bootstrap.php
     checkGenericClassInNonGenericObjectType: false

--- a/src/SprykerEco/Glue/AuthorizationPickingAppBackendApi/Controller/AuthorizeResourceController.php
+++ b/src/SprykerEco/Glue/AuthorizationPickingAppBackendApi/Controller/AuthorizeResourceController.php
@@ -33,8 +33,7 @@ class AuthorizeResourceController extends AbstractBackendApiController
     public function postAction(
         AuthCodeAttributesTransfer $authCodeAttributesTransfer,
         GlueRequestTransfer $glueRequestTransfer
-    ): GlueResponseTransfer
-    {
+    ): GlueResponseTransfer {
         $oauthRequestTransfer = (new OauthRequestTransfer())
             ->fromArray($authCodeAttributesTransfer->toArray(), true);
 

--- a/src/SprykerEco/Glue/AuthorizationPickingAppBackendApi/Controller/AuthorizeResourceController.php
+++ b/src/SprykerEco/Glue/AuthorizationPickingAppBackendApi/Controller/AuthorizeResourceController.php
@@ -33,14 +33,17 @@ class AuthorizeResourceController extends AbstractBackendApiController
     public function postAction(
         AuthCodeAttributesTransfer $authCodeAttributesTransfer,
         GlueRequestTransfer $glueRequestTransfer
-    ): GlueResponseTransfer {
+    ): GlueResponseTransfer
+    {
         $oauthRequestTransfer = (new OauthRequestTransfer())
             ->fromArray($authCodeAttributesTransfer->toArray(), true);
 
         $oauthResponseTransfer = $this->getFactory()->getAuthorizationPickingAppBackendApiFacade()->authorize($oauthRequestTransfer);
 
         $glueResponseTransfer = $this->mapAuthenticationAttributesToGlueResponseTransfer($oauthResponseTransfer);
-        $glueResponseTransfer->setHttpStatus(Response::HTTP_OK);
+        if (!$glueResponseTransfer->getHttpStatus()) {
+            $glueResponseTransfer->setHttpStatus(Response::HTTP_OK);
+        }
 
         return $glueResponseTransfer;
     }

--- a/src/SprykerEco/Glue/AuthorizationPickingAppBackendApi/Controller/AuthorizeResourceController.php
+++ b/src/SprykerEco/Glue/AuthorizationPickingAppBackendApi/Controller/AuthorizeResourceController.php
@@ -39,7 +39,10 @@ class AuthorizeResourceController extends AbstractBackendApiController
 
         $oauthResponseTransfer = $this->getFactory()->getAuthorizationPickingAppBackendApiFacade()->authorize($oauthRequestTransfer);
 
-        return $this->mapAuthenticationAttributesToGlueResponseTransfer($oauthResponseTransfer);
+        $glueResponseTransfer = $this->mapAuthenticationAttributesToGlueResponseTransfer($oauthResponseTransfer);
+        $glueResponseTransfer->setHttpStatus(Response::HTTP_OK);
+
+        return $glueResponseTransfer;
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @yaroslav-spryker

- Ticket: https://spryker.atlassian.net/browse/FRW-1928

- Release Group: https://release.spryker.com/release-groups/view/4818

- PR Overview: https://release.spryker.com/release/pull-request-eco/AuthorizationPickingAppBackendApi/4

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   AuthorizationPickingAppBackendApi  | minor (currently 0.x)  |                       |

-----------------------------------------

#### Module AuthorizationPickingAppBackendApi

##### Change log

Breaking Changes

Fixes

- Adjusted `AuthorizeResourceController::postAction()` to return a `200 OK` response code when the access token is created.
